### PR TITLE
improv: start a new selection only when clicking the mouse primary button or when the pointer device is not mouse

### DIFF
--- a/packages/swayze/lib/src/widgets/table_body/gestures/table_body_gesture_detector.dart
+++ b/packages/swayze/lib/src/widgets/table_body/gestures/table_body_gesture_detector.dart
@@ -314,6 +314,15 @@ class _TableBodyGestureDetectorState extends State<TableBodyGestureDetector> {
         return Listener(
           behavior: HitTestBehavior.translucent,
           onPointerDown: (details) {
+            final isMouse = details.kind == PointerDeviceKind.mouse;
+            final isPrimary = details.buttons == kPrimaryButton;
+
+            final shouldReact = !isMouse || isPrimary;
+
+            if (!shouldReact) {
+              return;
+            }
+
             final tableGestureDetails = _getTableGestureDetails(
               context,
               details.position,

--- a/packages/swayze/lib/src/widgets/table_body/gestures/table_body_gesture_detector.dart
+++ b/packages/swayze/lib/src/widgets/table_body/gestures/table_body_gesture_detector.dart
@@ -315,9 +315,9 @@ class _TableBodyGestureDetectorState extends State<TableBodyGestureDetector> {
           behavior: HitTestBehavior.translucent,
           onPointerDown: (details) {
             final isMouse = details.kind == PointerDeviceKind.mouse;
-            final isPrimary = details.buttons == kPrimaryButton;
+            final isPrimaryMouseButton = details.buttons == kPrimaryMouseButton;
 
-            final shouldReact = !isMouse || isPrimary;
+            final shouldReact = !isMouse || isPrimaryMouseButton;
 
             if (!shouldReact) {
               return;


### PR DESCRIPTION
### Context

Do not start a new selection when clicking the mouse button other than the primary one (useful for copying multiple cells in context menus).

### Approach

Update `table_body_gesture_detector.dart`'s `Listener.onPointerDown`.