### PR TITLE
improv: place inline editor in the closest `Overlay`, instead of the `Navigator`'s `Overlay`

### DIFF
--- a/packages/swayze/lib/src/widgets/inline_editor/inline_editor.dart
+++ b/packages/swayze/lib/src/widgets/inline_editor/inline_editor.dart
@@ -168,8 +168,7 @@ Rect? _getTableRect(BuildContext context) {
     return null;
   }
 
-  final overlay =
-      Navigator.of(context).overlay!.context.findRenderObject()! as RenderBox;
+  final overlay = Overlay.of(context)!.context.findRenderObject()! as RenderBox;
 
   final topLeft = MatrixUtils.transformPoint(
     table.getTransformTo(overlay),
@@ -194,7 +193,7 @@ Rect? _getCellRect({
   }
 
   final overlay =
-      (Navigator.of(context).overlay!.context.findRenderObject()! as RenderBox)
+      (Overlay.of(context)!.context.findRenderObject()! as RenderBox)
           .paintBounds;
 
   final displacedRect =

--- a/packages/swayze/lib/src/widgets/inline_editor/overlay.dart
+++ b/packages/swayze/lib/src/widgets/inline_editor/overlay.dart
@@ -249,7 +249,7 @@ class _TableOverlapCalculatorState extends State<_TableOverlapCalculator> {
       return;
     }
 
-    final overlay = Navigator.of(context).overlay!.context.findRenderObject()!;
+    final overlay = Overlay.of(context)!.context.findRenderObject()!;
 
     final translation =
         contextRenderObjectRect.getTransformTo(overlay).getTranslation();

--- a/packages/swayze/lib/src/widgets/table.dart
+++ b/packages/swayze/lib/src/widgets/table.dart
@@ -86,6 +86,9 @@ class SliverSwayzeTable<CellDataType extends SwayzeCellData>
   /// will edit a particular cell inline, that is, in the same physical spot
   /// occupied by the cell in the screen.
   ///
+  /// The inline editor will be added to the closest [Overlay]. If you haven't
+  /// defined one, it will default to the [Navigator]'s [Overlay].
+  ///
   /// See also:
   /// - [InlineEditorBuilder] for more details
   /// - [InlineEditorController] that controls the overall state of the


### PR DESCRIPTION
## Context

The inline editor was being placed in the `Navigator`'s `Overlay`. This is problematic because the user may want to create a more enclosing `Overlay` without creating a new `Navigator`. 

<!-- Place to describe the issue or to provide more information of why this PR is needed -->

### ⚠️ Breaking change ⚠️

**This is a breaking change**. It may break current consumers of this API, so a major version bump is required. 

Users affected by this breaking changes are users that: 
* are using `SliverSwayzeTable`'s `inlineEditorBuilder` function to build an inline cell editor, and;
* have an `Overlay` widget that is both:
  * a descendant of a `Navigator`, and;
  * ancestor of a `SliverSwayzeTable`.

Breaking change: if there is an `Overlay` between the `Navigator` and a `SliverSwayzeTable`, the inline cell editor will now render on that `Overlay`, instead of the `Navigator`'s. This may result in the wrong positioning of the inline cell editor.

## Approach

Use `Overlay.of()` instead of `Navigator.of().overlay` to obtain the closest `Overlay`

<!-- Place to describe the approach taken which can be an overview, list of created/changed components, where to look at -->