### PR TITLE
Prevents selecting a header that already is selected.

### DIFF
--- a/packages/swayze/CHANGELOG.md
+++ b/packages/swayze/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 1.2.0
 
-- Removes `id` property from `UserSelectionModel`.
+- Deprecates `id` property on `UserSelectionModel`.
 
 # 1.1.0
 

--- a/packages/swayze/CHANGELOG.md
+++ b/packages/swayze/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.2.0
+
+- Removes `id` property from `UserSelectionModel`.
+
 # 1.1.0
 
 - Bump `swayze_math` from 1.0.0 to 1.1.0

--- a/packages/swayze/lib/src/core/controller/selection/user_selections/model.dart
+++ b/packages/swayze/lib/src/core/controller/selection/user_selections/model.dart
@@ -2,19 +2,13 @@ import 'dart:math';
 
 import 'package:flutter/rendering.dart';
 import 'package:swayze_math/swayze_math.dart';
-import 'package:uuid/uuid.dart';
 
 import '../../../../helpers/basic_types.dart';
 import '../model/selection.dart';
 import '../model/selection_style.dart';
 
-const _uuid = Uuid();
-
 /// Defines a [Selection] that is controllable by a [UserSelectionState].
 abstract class UserSelectionModel extends Selection {
-  /// Unique identifier of a selection in a [UserSelectionState]
-  String get id;
-
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -28,22 +22,16 @@ abstract class UserSelectionModel extends Selection {
 /// It selects the entire table.
 class TableUserSelectionModel implements UserSelectionModel {
   @override
-  final String id;
-
-  @override
   final SelectionStyle? style = null;
 
   TableUserSelectionModel._({
-    String? id,
     required this.anchorCoordinate,
-  })  : id = id ?? _uuid.v4(),
-        super();
+  });
 
   factory TableUserSelectionModel.fromSelectionModel(
     UserSelectionModel original,
   ) {
     return TableUserSelectionModel._(
-      id: original.id,
       anchorCoordinate: original.anchorCoordinate,
     );
   }
@@ -71,12 +59,11 @@ class TableUserSelectionModel implements UserSelectionModel {
       identical(this, other) ||
       other is TableUserSelectionModel &&
           runtimeType == other.runtimeType &&
-          id == other.id &&
           style == other.style &&
           anchorCoordinate == other.anchorCoordinate;
 
   @override
-  int get hashCode => id.hashCode ^ style.hashCode ^ anchorCoordinate.hashCode;
+  int get hashCode => style.hashCode ^ anchorCoordinate.hashCode;
 }
 
 /// A [UserSelectionModel] that covers entire columns or rows.
@@ -90,23 +77,17 @@ class TableUserSelectionModel implements UserSelectionModel {
 /// It is always constructed via [AxisBoundedSelection.crossAxisUnbounded].
 class HeaderUserSelectionModel extends AxisBoundedSelection
     implements UserSelectionModel {
-  /// See [UserSelectionModel.id]
-  @override
-  final String id;
-
   /// See [UserSelectionModel.style]
   @override
   final SelectionStyle? style;
 
-  HeaderUserSelectionModel._({
-    String? id,
+  const HeaderUserSelectionModel._({
     required Axis boundedAxis,
     required RangeEdge anchorEdge,
     required int start,
     required int end,
     required this.style,
-  })  : id = id ?? _uuid.v4(),
-        super.crossAxisUnbounded(
+  }) : super.crossAxisUnbounded(
           axis: boundedAxis,
           anchorEdge: anchorEdge,
           start: start,
@@ -121,7 +102,6 @@ class HeaderUserSelectionModel extends AxisBoundedSelection
   /// Since this selection is simply a [Range], we convert [anchor] and [focus]
   /// into range's [start] and [end] values.
   factory HeaderUserSelectionModel.fromAnchorFocus({
-    String? id,
     required int anchor,
     required int focus,
     required Axis axis,
@@ -135,7 +115,6 @@ class HeaderUserSelectionModel extends AxisBoundedSelection
     final anchorEdge = anchor <= focus ? RangeEdge.leading : RangeEdge.trailing;
 
     return HeaderUserSelectionModel._(
-      id: id,
       anchorEdge: anchorEdge,
       start: start,
       end: end,
@@ -153,7 +132,6 @@ class HeaderUserSelectionModel extends AxisBoundedSelection
     required Axis axis,
   }) {
     return HeaderUserSelectionModel.fromAnchorFocus(
-      id: original.id,
       anchor: anchor,
       focus: focus,
       axis: axis,
@@ -173,7 +151,6 @@ class HeaderUserSelectionModel extends AxisBoundedSelection
     SelectionStyle? style,
   }) =>
       HeaderUserSelectionModel.fromAnchorFocus(
-        id: id,
         anchor: anchor ?? this.anchor,
         focus: focus ?? this.focus,
         axis: axis ?? this.axis,
@@ -189,7 +166,7 @@ class HeaderUserSelectionModel extends AxisBoundedSelection
           style == other.style);
 
   @override
-  int get hashCode => super.hashCode ^ id.hashCode ^ style.hashCode;
+  int get hashCode => super.hashCode ^ style.hashCode;
 }
 
 /// A [UserSelectionModel] that represents a [Range2D] of cells.
@@ -200,19 +177,14 @@ class HeaderUserSelectionModel extends AxisBoundedSelection
 class CellUserSelectionModel extends BoundedSelection
     implements UserSelectionModel {
   @override
-  final String id;
-
-  @override
   final SelectionStyle? style;
 
   CellUserSelectionModel._({
-    String? id,
     required IntVector2 leftTop,
     required IntVector2 rightBottom,
     required Corner anchorCorner,
     required this.style,
-  })  : id = id ?? _uuid.v4(),
-        super(
+  }) : super(
           leftTop: leftTop,
           rightBottom: rightBottom,
           anchorCorner: anchorCorner,
@@ -226,7 +198,6 @@ class CellUserSelectionModel extends BoundedSelection
   /// Since this selection is a [Range2D], we convert [anchor] and [focus]
   /// into range's [leftTop] and [rightBottom] values.
   factory CellUserSelectionModel.fromAnchorFocus({
-    String? id,
     required IntVector2 anchor,
     required IntVector2 focus,
     SelectionStyle? style,
@@ -255,7 +226,6 @@ class CellUserSelectionModel extends BoundedSelection
     }
 
     return CellUserSelectionModel._(
-      id: id,
       leftTop: leftTop,
       rightBottom: rightBottom,
       anchorCorner: anchorCorner,
@@ -271,7 +241,6 @@ class CellUserSelectionModel extends BoundedSelection
     required IntVector2 focus,
   }) {
     return CellUserSelectionModel.fromAnchorFocus(
-      id: original.id,
       anchor: anchor,
       focus: focus,
       style: original.style,
@@ -291,7 +260,6 @@ class CellUserSelectionModel extends BoundedSelection
     SelectionStyle? style,
   }) =>
       CellUserSelectionModel.fromAnchorFocus(
-        id: id,
         anchor: anchor ?? this.anchor,
         focus: focus ?? this.focus,
         style: style ?? this.style,
@@ -303,9 +271,8 @@ class CellUserSelectionModel extends BoundedSelection
       super == other &&
           other is CellUserSelectionModel &&
           runtimeType == other.runtimeType &&
-          id == other.id &&
           style == other.style;
 
   @override
-  int get hashCode => super.hashCode ^ id.hashCode ^ style.hashCode;
+  int get hashCode => super.hashCode ^ style.hashCode;
 }

--- a/packages/swayze/lib/src/core/controller/selection/user_selections/model.dart
+++ b/packages/swayze/lib/src/core/controller/selection/user_selections/model.dart
@@ -97,8 +97,6 @@ class HeaderUserSelectionModel extends AxisBoundedSelection
   /// Create a [HeaderUserSelectionModel] given its edges
   /// ([anchor] and [focus]).
   ///
-  /// if [id] is omitted, an uuid is generated.
-  ///
   /// Since this selection is simply a [Range], we convert [anchor] and [focus]
   /// into range's [start] and [end] values.
   factory HeaderUserSelectionModel.fromAnchorFocus({
@@ -192,8 +190,6 @@ class CellUserSelectionModel extends BoundedSelection
 
   /// Create a [CellUserSelectionModel] given its opposite corners
   /// ([anchor] and [focus]).
-  ///
-  /// If [id] is omitted, an uuid is generated.
   ///
   /// Since this selection is a [Range2D], we convert [anchor] and [focus]
   /// into range's [leftTop] and [rightBottom] values.

--- a/packages/swayze/lib/src/core/controller/selection/user_selections/model.dart
+++ b/packages/swayze/lib/src/core/controller/selection/user_selections/model.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+
 import 'dart:math';
 
 import 'package:flutter/rendering.dart';

--- a/packages/swayze/lib/src/core/controller/selection/user_selections/model.dart
+++ b/packages/swayze/lib/src/core/controller/selection/user_selections/model.dart
@@ -183,11 +183,10 @@ class HeaderUserSelectionModel extends AxisBoundedSelection
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      super == other &&
+      (super == other &&
           other is HeaderUserSelectionModel &&
           runtimeType == other.runtimeType &&
-          id == other.id &&
-          style == other.style;
+          style == other.style);
 
   @override
   int get hashCode => super.hashCode ^ id.hashCode ^ style.hashCode;

--- a/packages/swayze/lib/src/core/controller/selection/user_selections/model.dart
+++ b/packages/swayze/lib/src/core/controller/selection/user_selections/model.dart
@@ -2,13 +2,20 @@ import 'dart:math';
 
 import 'package:flutter/rendering.dart';
 import 'package:swayze_math/swayze_math.dart';
+import 'package:uuid/uuid.dart';
 
 import '../../../../helpers/basic_types.dart';
 import '../model/selection.dart';
 import '../model/selection_style.dart';
 
+const _uuid = Uuid();
+
 /// Defines a [Selection] that is controllable by a [UserSelectionState].
 abstract class UserSelectionModel extends Selection {
+  /// Unique identifier of a selection in a [UserSelectionState]
+  @Deprecated('')
+  String get id;
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -22,16 +29,22 @@ abstract class UserSelectionModel extends Selection {
 /// It selects the entire table.
 class TableUserSelectionModel implements UserSelectionModel {
   @override
+  @Deprecated('')
+  final String id;
+
+  @override
   final SelectionStyle? style = null;
 
   TableUserSelectionModel._({
+    @Deprecated('') String? id,
     required this.anchorCoordinate,
-  });
+  }) : id = id ?? _uuid.v4();
 
   factory TableUserSelectionModel.fromSelectionModel(
     UserSelectionModel original,
   ) {
     return TableUserSelectionModel._(
+      id: original.id,
       anchorCoordinate: original.anchorCoordinate,
     );
   }
@@ -59,11 +72,12 @@ class TableUserSelectionModel implements UserSelectionModel {
       identical(this, other) ||
       other is TableUserSelectionModel &&
           runtimeType == other.runtimeType &&
+          id == other.id &&
           style == other.style &&
           anchorCoordinate == other.anchorCoordinate;
 
   @override
-  int get hashCode => style.hashCode ^ anchorCoordinate.hashCode;
+  int get hashCode => id.hashCode ^ style.hashCode ^ anchorCoordinate.hashCode;
 }
 
 /// A [UserSelectionModel] that covers entire columns or rows.
@@ -77,17 +91,24 @@ class TableUserSelectionModel implements UserSelectionModel {
 /// It is always constructed via [AxisBoundedSelection.crossAxisUnbounded].
 class HeaderUserSelectionModel extends AxisBoundedSelection
     implements UserSelectionModel {
+  /// See [UserSelectionModel.id]
+  @override
+  @Deprecated('')
+  final String id;
+
   /// See [UserSelectionModel.style]
   @override
   final SelectionStyle? style;
 
-  const HeaderUserSelectionModel._({
+  HeaderUserSelectionModel._({
+    @Deprecated('') String? id,
     required Axis boundedAxis,
     required RangeEdge anchorEdge,
     required int start,
     required int end,
     required this.style,
-  }) : super.crossAxisUnbounded(
+  })  : id = id ?? _uuid.v4(),
+        super.crossAxisUnbounded(
           axis: boundedAxis,
           anchorEdge: anchorEdge,
           start: start,
@@ -97,9 +118,12 @@ class HeaderUserSelectionModel extends AxisBoundedSelection
   /// Create a [HeaderUserSelectionModel] given its edges
   /// ([anchor] and [focus]).
   ///
+  /// if [id] is omitted, an uuid is generated.
+  ///
   /// Since this selection is simply a [Range], we convert [anchor] and [focus]
   /// into range's [start] and [end] values.
   factory HeaderUserSelectionModel.fromAnchorFocus({
+    @Deprecated('') String? id,
     required int anchor,
     required int focus,
     required Axis axis,
@@ -113,6 +137,7 @@ class HeaderUserSelectionModel extends AxisBoundedSelection
     final anchorEdge = anchor <= focus ? RangeEdge.leading : RangeEdge.trailing;
 
     return HeaderUserSelectionModel._(
+      id: id,
       anchorEdge: anchorEdge,
       start: start,
       end: end,
@@ -130,6 +155,7 @@ class HeaderUserSelectionModel extends AxisBoundedSelection
     required Axis axis,
   }) {
     return HeaderUserSelectionModel.fromAnchorFocus(
+      id: original.id,
       anchor: anchor,
       focus: focus,
       axis: axis,
@@ -149,6 +175,7 @@ class HeaderUserSelectionModel extends AxisBoundedSelection
     SelectionStyle? style,
   }) =>
       HeaderUserSelectionModel.fromAnchorFocus(
+        id: id,
         anchor: anchor ?? this.anchor,
         focus: focus ?? this.focus,
         axis: axis ?? this.axis,
@@ -164,7 +191,7 @@ class HeaderUserSelectionModel extends AxisBoundedSelection
           style == other.style);
 
   @override
-  int get hashCode => super.hashCode ^ style.hashCode;
+  int get hashCode => super.hashCode ^ id.hashCode ^ style.hashCode;
 }
 
 /// A [UserSelectionModel] that represents a [Range2D] of cells.
@@ -175,14 +202,20 @@ class HeaderUserSelectionModel extends AxisBoundedSelection
 class CellUserSelectionModel extends BoundedSelection
     implements UserSelectionModel {
   @override
+  @Deprecated('')
+  final String id;
+
+  @override
   final SelectionStyle? style;
 
   CellUserSelectionModel._({
+    @Deprecated('') String? id,
     required IntVector2 leftTop,
     required IntVector2 rightBottom,
     required Corner anchorCorner,
     required this.style,
-  }) : super(
+  })  : id = id ?? _uuid.v4(),
+        super(
           leftTop: leftTop,
           rightBottom: rightBottom,
           anchorCorner: anchorCorner,
@@ -191,9 +224,12 @@ class CellUserSelectionModel extends BoundedSelection
   /// Create a [CellUserSelectionModel] given its opposite corners
   /// ([anchor] and [focus]).
   ///
+  /// If [id] is omitted, an uuid is generated.
+  ///
   /// Since this selection is a [Range2D], we convert [anchor] and [focus]
   /// into range's [leftTop] and [rightBottom] values.
   factory CellUserSelectionModel.fromAnchorFocus({
+    @Deprecated('') String? id,
     required IntVector2 anchor,
     required IntVector2 focus,
     SelectionStyle? style,
@@ -222,6 +258,7 @@ class CellUserSelectionModel extends BoundedSelection
     }
 
     return CellUserSelectionModel._(
+      id: id,
       leftTop: leftTop,
       rightBottom: rightBottom,
       anchorCorner: anchorCorner,
@@ -237,6 +274,7 @@ class CellUserSelectionModel extends BoundedSelection
     required IntVector2 focus,
   }) {
     return CellUserSelectionModel.fromAnchorFocus(
+      id: original.id,
       anchor: anchor,
       focus: focus,
       style: original.style,
@@ -256,6 +294,7 @@ class CellUserSelectionModel extends BoundedSelection
     SelectionStyle? style,
   }) =>
       CellUserSelectionModel.fromAnchorFocus(
+        id: id,
         anchor: anchor ?? this.anchor,
         focus: focus ?? this.focus,
         style: style ?? this.style,
@@ -267,8 +306,9 @@ class CellUserSelectionModel extends BoundedSelection
       super == other &&
           other is CellUserSelectionModel &&
           runtimeType == other.runtimeType &&
+          id == other.id &&
           style == other.style;
 
   @override
-  int get hashCode => super.hashCode ^ style.hashCode;
+  int get hashCode => super.hashCode ^ id.hashCode ^ style.hashCode;
 }

--- a/packages/swayze/lib/src/core/controller/selection/user_selections/user_selection_state.dart
+++ b/packages/swayze/lib/src/core/controller/selection/user_selections/user_selection_state.dart
@@ -77,6 +77,10 @@ class UserSelectionState {
   UserSelectionState addSelection(
     UserSelectionModel newSelection,
   ) {
+    if (selections.any((selection) => selection == newSelection)) {
+      return this;
+    }
+
     final newSelections =
         selections.rebuild((builder) => builder.add(newSelection));
 

--- a/packages/swayze/lib/src/widgets/table_body/selections/selections.dart
+++ b/packages/swayze/lib/src/widgets/table_body/selections/selections.dart
@@ -164,7 +164,7 @@ class _TableBodySelectionsState extends State<_TableBodySelections> {
           }
           children.add(
             PrimarySelection(
-              key: ValueKey(primary.id),
+              key: ValueKey(primary),
               selectionModel: primary,
               activeCellRect: activeCellRect,
               xRange: xRange,

--- a/packages/swayze/pubspec.yaml
+++ b/packages/swayze/pubspec.yaml
@@ -1,6 +1,6 @@
 name: swayze
 description: A set of widgets and controllers to display very large tables on flutter apps.
-version: 1.1.0
+version: 1.2.0
 repository: https://github.com/rows/swayze
 issue_tracker: https://github.com/rows/swayze/issues
 homepage: https://github.com/rows/swayze


### PR DESCRIPTION
### Related to

N/A

### Context

We should not add a header to a selection that already has that header selected.

### Approach

- Added a check on `UserSelectionState.addSelection` to prevent a selection to be added twice.
- Removed the unused id property from the `UserSelectionModel`, as same selections can have different ids. We could remove the entire `UserSelectionModel` abstract class, and use `Selection` directly, but that would break the API.