### PR TITLE
improv: allow defining limits for elastic grid

### DIFF
--- a/packages/swayze/CHANGELOG.md
+++ b/packages/swayze/CHANGELOG.md
@@ -1,6 +1,14 @@
-# 1.2.0
+# 1.4.0
 
 - Deprecates `id` property on `UserSelectionModel`.
+
+# 1.3.0
+
+- Allow resizing of columns or rows.
+
+# 1.2.0
+
+- Add drag and drop for columns and rows.
 
 # 1.1.0
 
@@ -8,7 +16,7 @@
 
 # 1.0.3
 
-- Fix `SwayzeSliverTable` using `Navigator`'s `overlay` property instead of fetching the closest 
+- Fix `SwayzeSliverTable` using `Navigator`'s `overlay` property instead of fetching the closest
   `Overlay` ancestor.
 
 # 1.0.2

--- a/packages/swayze/CHANGELOG.md
+++ b/packages/swayze/CHANGELOG.md
@@ -1,13 +1,7 @@
-# 1.4.0
-
-- Deprecates `id` property on `UserSelectionModel`.
-
-# 1.3.0
-
-- Allow resizing of columns or rows.
-
 # 1.2.0
 
+- Deprecates `id` property on `UserSelectionModel`.
+- Allow resizing of columns or rows.
 - Add drag and drop for columns and rows.
 
 # 1.1.0

--- a/packages/swayze/lib/src/core/controller/cells/cells_controller.dart
+++ b/packages/swayze/lib/src/core/controller/cells/cells_controller.dart
@@ -246,7 +246,7 @@ class SwayzeCellsController<CellDataType extends SwayzeCellData>
           axis == Axis.horizontal ? newCoordinate.dx : newCoordinate.dy;
 
       final maxPosition = elasticCount != null
-          // in case the user has settled a max elastic count, we should
+          // in case the user has set a max elastic count, we should
           // limit the grid expansion to that count, however, if that limit
           // is lower than the table size, we should prioritize the table size
           // over it.

--- a/packages/swayze/lib/src/core/controller/cells/cells_controller.dart
+++ b/packages/swayze/lib/src/core/controller/cells/cells_controller.dart
@@ -226,6 +226,9 @@ class SwayzeCellsController<CellDataType extends SwayzeCellData>
     final axis = axisDirectionToAxis(direction);
     final headerController =
         parent.tableDataController.getHeaderControllerFor(axis: axis);
+    final maxElasticColumns = parent.tableDataController.maxElasticColumns;
+    final maxElasticRows = parent.tableDataController.maxElasticRows;
+
     var newCoordinate = originalCoordinate;
 
     bool shouldContinueLookup(IntVector2 curr) {
@@ -238,9 +241,18 @@ class SwayzeCellsController<CellDataType extends SwayzeCellData>
     // finds the a suitable coordinate.
     do {
       newCoordinate += _moveVectors[direction]!;
+
+      final dx = maxElasticColumns != null
+          ? min(newCoordinate.dx, maxElasticColumns - 1)
+          : newCoordinate.dx;
+
+      final dy = maxElasticRows != null
+          ? min(newCoordinate.dy, maxElasticRows - 1)
+          : newCoordinate.dy;
+
       newCoordinate = IntVector2(
-        axis == Axis.horizontal ? max(0, newCoordinate.dx) : newCoordinate.dx,
-        axis == Axis.vertical ? max(0, newCoordinate.dy) : newCoordinate.dy,
+        axis == Axis.horizontal ? max(0, dx) : newCoordinate.dx,
+        axis == Axis.vertical ? max(0, dy) : newCoordinate.dy,
       );
     } while (shouldContinueLookup(newCoordinate));
 

--- a/packages/swayze/lib/src/core/controller/cells/cells_controller.dart
+++ b/packages/swayze/lib/src/core/controller/cells/cells_controller.dart
@@ -228,6 +228,8 @@ class SwayzeCellsController<CellDataType extends SwayzeCellData>
         parent.tableDataController.getHeaderControllerFor(axis: axis);
     final maxElasticColumns = parent.tableDataController.maxElasticColumns;
     final maxElasticRows = parent.tableDataController.maxElasticRows;
+    final columnsCount = parent.tableDataController.columns.value.count;
+    final rowsCount = parent.tableDataController.rows.value.count;
 
     var newCoordinate = originalCoordinate;
 
@@ -243,11 +245,11 @@ class SwayzeCellsController<CellDataType extends SwayzeCellData>
       newCoordinate += _moveVectors[direction]!;
 
       final dx = maxElasticColumns != null
-          ? min(newCoordinate.dx, maxElasticColumns - 1)
+          ? min(newCoordinate.dx, max(maxElasticColumns - 1, columnsCount - 1))
           : newCoordinate.dx;
 
       final dy = maxElasticRows != null
-          ? min(newCoordinate.dy, maxElasticRows - 1)
+          ? min(newCoordinate.dy, max(maxElasticRows - 1, rowsCount - 1))
           : newCoordinate.dy;
 
       newCoordinate = IntVector2(

--- a/packages/swayze/lib/src/core/controller/cells/cells_controller.dart
+++ b/packages/swayze/lib/src/core/controller/cells/cells_controller.dart
@@ -226,10 +226,6 @@ class SwayzeCellsController<CellDataType extends SwayzeCellData>
     final axis = axisDirectionToAxis(direction);
     final headerController =
         parent.tableDataController.getHeaderControllerFor(axis: axis);
-    final maxElasticColumns = parent.tableDataController.maxElasticColumns;
-    final maxElasticRows = parent.tableDataController.maxElasticRows;
-    final columnsCount = parent.tableDataController.columns.value.count;
-    final rowsCount = parent.tableDataController.rows.value.count;
 
     var newCoordinate = originalCoordinate;
 
@@ -244,17 +240,19 @@ class SwayzeCellsController<CellDataType extends SwayzeCellData>
     do {
       newCoordinate += _moveVectors[direction]!;
 
-      final dx = maxElasticColumns != null
-          ? min(newCoordinate.dx, max(maxElasticColumns - 1, columnsCount - 1))
-          : newCoordinate.dx;
+      final elasticCount = headerController.value.maxElasticCount;
+      final count = headerController.value.count;
 
-      final dy = maxElasticRows != null
-          ? min(newCoordinate.dy, max(maxElasticRows - 1, rowsCount - 1))
-          : newCoordinate.dy;
+      final position =
+          axis == Axis.horizontal ? newCoordinate.dx : newCoordinate.dy;
+
+      final maxPosition = elasticCount != null
+          ? min(position, max(elasticCount - 1, count - 1))
+          : position;
 
       newCoordinate = IntVector2(
-        axis == Axis.horizontal ? max(0, dx) : newCoordinate.dx,
-        axis == Axis.vertical ? max(0, dy) : newCoordinate.dy,
+        axis == Axis.horizontal ? max(0, maxPosition) : newCoordinate.dx,
+        axis == Axis.vertical ? max(0, maxPosition) : newCoordinate.dy,
       );
     } while (shouldContinueLookup(newCoordinate));
 

--- a/packages/swayze/lib/src/core/controller/cells/cells_controller.dart
+++ b/packages/swayze/lib/src/core/controller/cells/cells_controller.dart
@@ -226,7 +226,6 @@ class SwayzeCellsController<CellDataType extends SwayzeCellData>
     final axis = axisDirectionToAxis(direction);
     final headerController =
         parent.tableDataController.getHeaderControllerFor(axis: axis);
-
     var newCoordinate = originalCoordinate;
 
     bool shouldContinueLookup(IntVector2 curr) {
@@ -247,6 +246,10 @@ class SwayzeCellsController<CellDataType extends SwayzeCellData>
           axis == Axis.horizontal ? newCoordinate.dx : newCoordinate.dy;
 
       final maxPosition = elasticCount != null
+          // in case the user has settled a max elastic count, we should
+          // limit the grid expansion to that count, however, if that limit
+          // is lower than the table size, we should prioritize the table size
+          // over it.
           ? min(position, max(elasticCount - 1, count - 1))
           : position;
 

--- a/packages/swayze/lib/src/core/controller/table/header_state.dart
+++ b/packages/swayze/lib/src/core/controller/table/header_state.dart
@@ -139,9 +139,7 @@ class SwayzeHeaderState {
     if (headerData != null) {
       return SwayzeHeaderState(
         elasticCount: elasticCount ?? this.elasticCount,
-        maxElasticCount: maxElasticCount != null
-            ? maxElasticCount.value
-            : this.maxElasticCount,
+        maxElasticCount: maxElasticCount?.value ?? this.maxElasticCount,
         defaultHeaderExtent: defaultHeaderExtent,
         count: count ?? this.count,
         headerData: headerData,
@@ -152,9 +150,7 @@ class SwayzeHeaderState {
 
     return SwayzeHeaderState._fromSortedHeaderData(
       elasticCount: elasticCount ?? this.elasticCount,
-      maxElasticCount: maxElasticCount != null
-          ? maxElasticCount.value
-          : this.maxElasticCount,
+      maxElasticCount: maxElasticCount?.value ?? this.maxElasticCount,
       defaultHeaderExtent: defaultHeaderExtent,
       count: count ?? this.count,
       sortedHeaderData: _customSizedHeaders,

--- a/packages/swayze/lib/src/core/controller/table/header_state.dart
+++ b/packages/swayze/lib/src/core/controller/table/header_state.dart
@@ -32,6 +32,8 @@ class SwayzeHeaderState {
   /// elastic expansion.
   final int elasticCount;
 
+  final int? maxElasticCount;
+
   /// The amount of headers in this axis.
   final int count;
 
@@ -96,6 +98,7 @@ class SwayzeHeaderState {
     required Iterable<SwayzeHeaderData> headerData,
     required int frozenCount,
     int? elasticCount,
+    this.maxElasticCount,
     this.dragState,
   })  : _frozenCount = frozenCount,
         elasticCount = elasticCount ?? 0,
@@ -115,6 +118,7 @@ class SwayzeHeaderState {
     required SplayTreeMap<int, SwayzeHeaderData> sortedHeaderData,
     required int frozenCount,
     this.dragState,
+    this.maxElasticCount,
   })  : _frozenCount = frozenCount,
         _customSizedHeaders = sortedHeaderData;
 
@@ -125,6 +129,7 @@ class SwayzeHeaderState {
   SwayzeHeaderState copyWith({
     int? count,
     int? elasticCount,
+    Wrapped<int?>? maxElasticCount,
     Iterable<SwayzeHeaderData>? headerData,
     int? frozenCount,
     Wrapped<SwayzeHeaderDragState?>? dragState,
@@ -132,6 +137,9 @@ class SwayzeHeaderState {
     if (headerData != null) {
       return SwayzeHeaderState(
         elasticCount: elasticCount ?? this.elasticCount,
+        maxElasticCount: maxElasticCount != null
+            ? maxElasticCount.value
+            : this.maxElasticCount,
         defaultHeaderExtent: defaultHeaderExtent,
         count: count ?? this.count,
         headerData: headerData,
@@ -142,6 +150,9 @@ class SwayzeHeaderState {
 
     return SwayzeHeaderState._fromSortedHeaderData(
       elasticCount: elasticCount ?? this.elasticCount,
+      maxElasticCount: maxElasticCount != null
+          ? maxElasticCount.value
+          : this.maxElasticCount,
       defaultHeaderExtent: defaultHeaderExtent,
       count: count ?? this.count,
       sortedHeaderData: _customSizedHeaders,
@@ -172,6 +183,7 @@ class SwayzeHeaderState {
 
     return SwayzeHeaderState._fromSortedHeaderData(
       elasticCount: elasticCount,
+      maxElasticCount: maxElasticCount,
       defaultHeaderExtent: defaultHeaderExtent,
       count: count,
       sortedHeaderData: _newCustomSizedHeaders,
@@ -193,6 +205,7 @@ class SwayzeHeaderState {
           defaultHeaderExtent == other.defaultHeaderExtent &&
           count == other.count &&
           elasticCount == other.elasticCount &&
+          maxElasticCount == other.maxElasticCount &&
           dragState == other.dragState &&
           _kMapEquality.equals(customSizedHeaders, other.customSizedHeaders);
 
@@ -202,6 +215,7 @@ class SwayzeHeaderState {
       defaultHeaderExtent.hashCode ^
       count.hashCode ^
       elasticCount.hashCode ^
+      maxElasticCount.hashCode ^
       customSizedHeaders.hashCode ^
       dragState.hashCode;
 
@@ -212,6 +226,7 @@ class SwayzeHeaderState {
       defaultHeaderExtent: $defaultHeaderExtent,
       count: $count,
       elasticCount: $elasticCount,
+      maxElasticCount: $maxElasticCount,
       orderedCustomSizedIndices: $orderedCustomSizedIndices,
       hasCustomSizes: $hasCustomSizes,
       customSizedHeaders: $customSizedHeaders,

--- a/packages/swayze/lib/src/core/controller/table/header_state.dart
+++ b/packages/swayze/lib/src/core/controller/table/header_state.dart
@@ -32,6 +32,8 @@ class SwayzeHeaderState {
   /// elastic expansion.
   final int elasticCount;
 
+  /// The maximum amount allowed of headers in this axis that exist only due to
+  /// table's elastic expansion.
   final int? maxElasticCount;
 
   /// The amount of headers in this axis.

--- a/packages/swayze/lib/src/core/controller/table/table_controller.dart
+++ b/packages/swayze/lib/src/core/controller/table/table_controller.dart
@@ -38,6 +38,10 @@ class SwayzeTableDataController<ParentType extends SwayzeController>
   /// A [SwayzeHeaderController] for the vertical axis
   final SwayzeHeaderController rows;
 
+  final int? maxElasticColumns;
+
+  final int? maxElasticRows;
+
   /// Merged [Listenable] to listen for changes on [columns] and [rows].
   late final _columnsAndRowsListenable = Listenable.merge([columns, rows]);
 
@@ -50,6 +54,8 @@ class SwayzeTableDataController<ParentType extends SwayzeController>
     required Iterable<SwayzeHeaderData> rows,
     required int frozenColumns,
     required int frozenRows,
+    this.maxElasticColumns,
+    this.maxElasticRows,
   })  : columns = SwayzeHeaderController._(
           initialState: SwayzeHeaderState(
             defaultHeaderExtent: config.kDefaultCellWidth,
@@ -134,8 +140,12 @@ class SwayzeTableDataController<ParentType extends SwayzeController>
     }
 
     scheduleMicrotask(() {
-      columns.updateElasticCount(elasticEdge.dx);
-      rows.updateElasticCount(elasticEdge.dy);
+      columns.updateElasticCount(
+        min(maxElasticColumns ?? elasticEdge.dx, elasticEdge.dx),
+      );
+      rows.updateElasticCount(
+        min(maxElasticRows ?? elasticEdge.dy, elasticEdge.dy),
+      );
     });
   }
 

--- a/packages/swayze/lib/src/core/controller/table/table_controller.dart
+++ b/packages/swayze/lib/src/core/controller/table/table_controller.dart
@@ -38,9 +38,9 @@ class SwayzeTableDataController<ParentType extends SwayzeController>
   /// A [SwayzeHeaderController] for the vertical axis
   final SwayzeHeaderController rows;
 
-  final int? maxElasticColumns;
+  final int? _maxElasticColumns;
 
-  final int? maxElasticRows;
+  final int? _maxElasticRows;
 
   /// Merged [Listenable] to listen for changes on [columns] and [rows].
   late final _columnsAndRowsListenable = Listenable.merge([columns, rows]);
@@ -54,14 +54,15 @@ class SwayzeTableDataController<ParentType extends SwayzeController>
     required Iterable<SwayzeHeaderData> rows,
     required int frozenColumns,
     required int frozenRows,
-    this.maxElasticColumns,
-    this.maxElasticRows,
+    int? maxElasticColumns,
+    int? maxElasticRows,
   })  : columns = SwayzeHeaderController._(
           initialState: SwayzeHeaderState(
             defaultHeaderExtent: config.kDefaultCellWidth,
             count: columnCount,
             headerData: columns,
             frozenCount: frozenColumns,
+            maxElasticCount: maxElasticColumns,
           ),
         ),
         rows = SwayzeHeaderController._(
@@ -70,8 +71,11 @@ class SwayzeTableDataController<ParentType extends SwayzeController>
             count: rowCount,
             headerData: rows,
             frozenCount: frozenRows,
+            maxElasticCount: maxElasticRows,
           ),
         ),
+        _maxElasticColumns = maxElasticColumns,
+        _maxElasticRows = maxElasticRows,
         super() {
     parent.selection.addListener(handleSelectionChange);
   }
@@ -141,10 +145,10 @@ class SwayzeTableDataController<ParentType extends SwayzeController>
 
     scheduleMicrotask(() {
       columns.updateElasticCount(
-        min(maxElasticColumns ?? elasticEdge.dx, elasticEdge.dx),
+        min(_maxElasticColumns ?? elasticEdge.dx, elasticEdge.dx),
       );
       rows.updateElasticCount(
-        min(maxElasticRows ?? elasticEdge.dy, elasticEdge.dy),
+        min(_maxElasticRows ?? elasticEdge.dy, elasticEdge.dy),
       );
     });
   }

--- a/packages/swayze/lib/src/core/controller/table/table_controller.dart
+++ b/packages/swayze/lib/src/core/controller/table/table_controller.dart
@@ -38,8 +38,10 @@ class SwayzeTableDataController<ParentType extends SwayzeController>
   /// A [SwayzeHeaderController] for the vertical axis
   final SwayzeHeaderController rows;
 
+  /// The maximum amount of columns allowed in elastic expansion.
   final int? _maxElasticColumns;
 
+  /// The maximum amount of rows allowed in elastic expansion.
   final int? _maxElasticRows;
 
   /// Merged [Listenable] to listen for changes on [columns] and [rows].

--- a/packages/swayze/test/core/controller/table/table_controller_test.dart
+++ b/packages/swayze/test/core/controller/table/table_controller_test.dart
@@ -260,5 +260,77 @@ void main() {
         expect(tableDataController.tableRange, _kTestDefaultTableRange);
       },
     );
+
+    group('elastic grid', () {
+      test('should not expand table beyond elastic limits', () async {
+        final parent = createSwayzeController();
+        final tableDataController = SwayzeTableDataController(
+          parent: parent,
+          id: 'id',
+          columnCount: 5,
+          rowCount: 5,
+          frozenColumns: 1,
+          frozenRows: 2,
+          columns: [],
+          rows: [],
+          maxElasticColumns: 10,
+          maxElasticRows: 10,
+        );
+
+        expect(tableDataController.tableRange, _kTestDefaultTableRange);
+
+        await addUserSelection(
+          parent.selection,
+          CellUserSelectionModel.fromAnchorFocus(
+            anchor: const IntVector2(15, 16),
+            focus: const IntVector2(17, 18),
+          ),
+        );
+
+        expect(
+          tableDataController.tableRange,
+          Range2D.fromLTWH(
+            const IntVector2.symmetric(0),
+            const IntVector2(10, 10),
+          ),
+        );
+      });
+
+      test(
+          'should be able to select any cell of the table when elastic limits '
+          'are lower than table size', () async {
+        final parent = createSwayzeController();
+        final tableDataController = SwayzeTableDataController(
+          parent: parent,
+          id: 'id',
+          columnCount: 5,
+          rowCount: 5,
+          frozenColumns: 1,
+          frozenRows: 2,
+          columns: [],
+          rows: [],
+          maxElasticColumns: 3,
+          maxElasticRows: 3,
+        );
+
+        expect(tableDataController.tableRange, _kTestDefaultTableRange);
+
+        await addUserSelection(
+          parent.selection,
+          CellUserSelectionModel.fromAnchorFocus(
+            anchor: const IntVector2(15, 16),
+            focus: const IntVector2(17, 18),
+          ),
+        );
+
+        expect(
+          tableDataController.tableRange,
+          Range2D.fromLTWH(
+            const IntVector2.symmetric(0),
+            const IntVector2(5, 5),
+          ),
+        );
+      });
+    });
   });
 }


### PR DESCRIPTION
### Context

Allows defining the max amount of columns or rows that the elastic grid can have.

### Approach

Allows to settle `maxElasticColumns` and `maxElasticRows` on `SwayzeTableDataController`.