### PR TITLE
fix: column min extent

### DIFF
--- a/packages/swayze/lib/src/config.dart
+++ b/packages/swayze/lib/src/config.dart
@@ -24,5 +24,7 @@ double headerWidthForRange(Range range) {
 const kDefaultCellWidth = 120.0;
 const kDefaultCellHeight = 33.0;
 
+const kMinCellWidth = 30.0;
+
 const kDefaultScrollAnimationDuration = Duration(milliseconds: 50);
 const kDefaultScrollAnimationCurve = Curves.easeOut;

--- a/packages/swayze/lib/src/widgets/headers/gestures/resize_header/header_edge_mouse_listener.dart
+++ b/packages/swayze/lib/src/widgets/headers/gestures/resize_header/header_edge_mouse_listener.dart
@@ -176,7 +176,7 @@ class _HeaderEdgeMouseListenerState extends State<HeaderEdgeMouseListener> {
   }
 
   double minExtent(Axis axis) =>
-      axis == Axis.horizontal ? kDefaultCellWidth : kDefaultCellHeight;
+      axis == Axis.horizontal ? kMinCellWidth : kDefaultCellHeight;
 
   /// Inserts an [OverlayEntry] to the current [OverlayState] with resize line
   /// on it at the header edge that is being hovered.


### PR DESCRIPTION
### Context

Users should be able to resize columns to a smaller width.

Since there are more things that need to be configurable for resize, configuring this extent is out of scope of this PR.