### PR TITLE
fix: Use TargetPlatform instead of Platform

### DIFF
--- a/packages/swayze/lib/src/core/scrolling/pointer_scroll_detector.dart
+++ b/packages/swayze/lib/src/core/scrolling/pointer_scroll_detector.dart
@@ -1,5 +1,4 @@
-import 'dart:io';
-
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -93,7 +92,7 @@ class PointerScrollDetector extends StatelessWidget {
     /// TODO(renancaraujo): windows doesnt automatically applies shift+scroll
     /// as horizontal scroll. This is a workaround and doesnt work if the app
     /// is not focused. To track: https://github.com/flutter/flutter/issues/75180
-    if (Platform.isWindows && containsShift) {
+    if (defaultTargetPlatform == TargetPlatform.windows && containsShift) {
       if (axis == Axis.vertical) {
         return 0.0;
       }

--- a/packages/swayze/lib/src/widgets/default_actions/selection_actions.dart
+++ b/packages/swayze/lib/src/widgets/default_actions/selection_actions.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
-import 'dart:io';
 import 'dart:math';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:swayze_math/swayze_math.dart';
@@ -660,7 +660,8 @@ class HeaderSelectionUpdateAction
 
 extension on Set<LogicalKeyboardKey> {
   bool get containsModifier {
-    final isDarwin = Platform.isMacOS || Platform.isIOS;
+    final isDarwin = defaultTargetPlatform == TargetPlatform.macOS ||
+        defaultTargetPlatform == TargetPlatform.iOS;
     return isDarwin
         ? contains(LogicalKeyboardKey.meta)
         : contains(LogicalKeyboardKey.control);


### PR DESCRIPTION
### Related to
NA

### Context
When running Swayze on the web we can't use `Platform`

### Approach
Use `TargetPlatform` as we already do in other places of Swayze.